### PR TITLE
Relax faker version dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-blacksmith
+Blacksmith
 ==========
 
 Data generation framework for Elixir.
@@ -7,11 +7,11 @@ In testing, sometimes it's useful to create records in the form of maps. Blacksm
 
 First, install Blacksmith:
 
-Right now, you'll use mix with a git dependency. In your mix.exs file, add the blacksmith dependency:
+In your mix.exs file, add the blacksmith dependency:
 
 ~~~elixir
 def deps do
-  [{:blacksmith, git: "git://github.com/batate/blacksmith.git"}]
+  [{:blacksmith, "~> 0.1"}]
 end
 ~~~
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Blacksmith.Mixfile do
   end
 
   defp deps do
-    [{:faker, "~> 0.4.0"},
+    [{:faker, "~> 0.5"},
      {:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:shouldi, only: :test}]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "faker": {:hex, :faker, "0.4.1"},
+  "faker": {:hex, :faker, "0.5.0"},
   "poison": {:hex, :poison, "1.3.1"},
   "shouldi": {:hex, :shouldi, "0.2.2"}}


### PR DESCRIPTION
Assuming that Faker sticks to semver, there's no need to lock down the version to 0.4.x.