### PR TITLE
Update version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In your mix.exs file, add the blacksmith dependency:
 
 ~~~elixir
 def deps do
-  [{:blacksmith, "~> 0.1"}]
+  [{:blacksmith, "~> 0.1.2"}]
 end
 ~~~
 


### PR DESCRIPTION
The docs Readme describes setup for 0.1.2, but specifying ~> 0.1 in deps caused mix to grab 0.1.0, which conflicted with the instructions.  Because this is a breaking change, I think you should bump the version to 0.2.0