### PR TITLE
Fix unsafe conditional variable assignment warning

### DIFF
--- a/lib/blacksmith.ex
+++ b/lib/blacksmith.ex
@@ -95,10 +95,10 @@ defmodule Blacksmith do
   end
 
   def new(attributes, overrides, module, opts) do
-    if prototype = opts[:prototype] do
-      map = apply(module, prototype, []) |> to_map
+    map = if (prototype = opts[:prototype]) do
+      apply(module, prototype, []) |> to_map
     else
-      map = %{}
+      %{}
     end
 
     attributes = to_map(attributes)


### PR DESCRIPTION
This fixes the following warnings:

```
lib/blacksmith.ex:107: warning: the variable "map" is unsafe as it has been defined in a conditional clause, as part of a case/cond/receive/if/&&/||. Please rewrite the clauses so the value is explicitly returned. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

Can be rewritten as:

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

lib/blacksmith.ex:111: warning: the variable "map" is unsafe as it has been defined in a conditional clause, as part of a case/cond/receive/if/&&/||. Please rewrite the clauses so the value is explicitly returned. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

Can be rewritten as:

    atom =
      case int do
        1 -> :one
        2 -> :two
      end
```