### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ defmodule Forge do
 
   # this will create a user with roles set to [:admin]
   register :admin,
-    [prototype: user],
+    [prototype: :user],
     roles: ["admin"]
 end
 ~~~


### PR DESCRIPTION
This PR make the prototype example works. Although is a minor typo but so confusing especially for elixir newcomers. 