### PR TITLE
Fix compilation error on Elixir 1.13+

### DIFF
--- a/lib/blacksmith.ex
+++ b/lib/blacksmith.ex
@@ -41,7 +41,7 @@ defmodule Blacksmith do
           ast
       end)
 
-    var_defined? = {:opts_var, env.module} in caller.vars
+    var_defined? = {:opts_var, env.module} in Macro.Env.vars(caller)
     opts = Blacksmith.append_opts(opts_var, var_defined?, opts)
 
     quote do


### PR DESCRIPTION
The internal `Macro.Env` structure changed on newer versions of Elixir (1.13+) and they no longer have a `vars` field which is causing a compilation error on newer versions.

The change is very minimal and I verified that the function exists on older versions of Elixir (I went back as far as 1.7.0).